### PR TITLE
Drop messages from batch on disconnect

### DIFF
--- a/lib/input/reader/amqp_1.go
+++ b/lib/input/reader/amqp_1.go
@@ -262,7 +262,7 @@ func (a *AMQP1) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn,
 	a.m.RUnlock()
 
 	return msg, func(ctx context.Context, res types.Response) error {
-		msg, ok := a.popPendingMessage(amqpMsg)
+		msg, ok := a.takePendingMessage(amqpMsg)
 		if !ok {
 			return nil
 		}
@@ -278,7 +278,7 @@ func (a *AMQP1) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn,
 	}, nil
 }
 
-func (a *AMQP1) popPendingMessage(amqpMsg *amqp.Message) (*amqp1PendingMsg, bool) {
+func (a *AMQP1) takePendingMessage(amqpMsg *amqp.Message) (*amqp1PendingMsg, bool) {
 	a.m.Lock()
 	defer a.m.Unlock()
 	msg, ok := a.pendingMsgs[pendingMsgIndex(amqpMsg)]

--- a/lib/input/reader/amqp_1.go
+++ b/lib/input/reader/amqp_1.go
@@ -256,7 +256,7 @@ func (a *AMQP1) ReadWithContext(ctx context.Context) (types.Message, AsyncAckFn,
 
 	a.m.RLock()
 	a.pendingMsgs[pendingMsgIndex(amqpMsg)] = &amqp1PendingMsg{
-		msg: msg,
+		msg:              msg,
 		renewDoneChannel: renewDoneChannel,
 	}
 	a.m.RUnlock()

--- a/lib/message/batch/policy.go
+++ b/lib/message/batch/policy.go
@@ -223,7 +223,7 @@ func (p *Policy) clear() {
 		if part.Metadata().Get("source_msg_lost") != "true" {
 			newParts = append(newParts, part)
 		} else {
-			p.log.Infoln("lost message")
+			p.log.Infoln("source message expired")
 		}
 	}
 	p.parts = newParts

--- a/lib/message/batch/policy.go
+++ b/lib/message/batch/policy.go
@@ -217,8 +217,7 @@ func NewPolicy(
 	}, nil
 }
 
-//------------------------------------------------------------------------------
-func (p *Policy) Clear() {
+func (p *Policy) clear() {
 	newParts := make([]types.Part, 0, len(p.parts))
 	for _, part := range p.parts {
 		if part.Metadata().Get("source_msg_lost") != "true" {
@@ -230,13 +229,15 @@ func (p *Policy) Clear() {
 	p.parts = newParts
 }
 
+//------------------------------------------------------------------------------
+
 // Add a new message part to this batch policy. Returns true if this part
 // triggers the conditions of the policy.
 func (p *Policy) Add(part types.Part) bool {
 	p.sizeTally += len(part.Get())
 	p.parts = append(p.parts, part)
 
-	p.Clear()
+	p.clear()
 
 	if !p.triggered && p.count > 0 && len(p.parts) >= p.count {
 		p.triggered = true
@@ -275,7 +276,7 @@ func (p *Policy) Add(part types.Part) bool {
 // policy is currently empty.
 func (p *Policy) Flush() types.Message {
 	var newMsg types.Message
-	p.Clear()
+	p.clear()
 
 	resultMsgs := p.FlushAny()
 	if len(resultMsgs) == 1 {


### PR DESCRIPTION
When we're disconnected from the Azure we lose lock on the messages that we're processing and they are redelivered. This causes both, premature batch flush and duplicated claims. For example:
 1. assume  we have batch configured to max 4 elements
 2. we receive messages: a,b,c
 3. azure disconnects so we lose lock on messages a,b,c
 4. we reconnect
 5. azure redeliver messages a,b,c
 6. first batch gets full (messages: a,b,c,a) so it's flushes
 7. we detect duplicates but the batch is already flushed so we register claims a, b, and c (3 despite batch size is set to 4)
 8. messages b and c starts a new batch
 9. we receive new claims d, e
 10. the second batch is triggered (with messages b,c,d,e) there are no duplicates in this batch so all of them get registered

After this we end up with 2 transactions:
1. with claims a,b,c
2. with claims b,c,d,e
So the first batch isn't full and the second contains duplicates.
 
 To solve this issue this PR changes that on disconnect all messages are invalidated before the batch is triggered so it's not flushed due to redelivered messages.
 